### PR TITLE
Fix onchain state example

### DIFF
--- a/examples/onchain-state/main.go
+++ b/examples/onchain-state/main.go
@@ -11,19 +11,22 @@ func main() {
 	fr := framework.New()
 	contract := fr.DeployContract("onchain-state.sol/OnChainState.json")
 
-	fmt.Println("1. Send a confidential request that cannot modify the state")
+	fmt.Println("1. A confidential request fails if it tries to modify the state")
 
-	contract.SendTransaction("nilExample", nil, nil)
-	val := contract.Call("getState")[0].(uint64)
-	if val != 0 {
-		fmt.Printf("expected 0")
+	_, err := contract.Raw().SendTransaction("nilExample", nil, nil)
+	if err != nil {
+		fmt.Println("expected an error")
 		os.Exit(1)
 	}
 
 	fmt.Println("2. Send a confidential request that modifies the state")
 
 	contract.SendTransaction("example", nil, nil)
-	val = contract.Call("getState")[0].(uint64)
+	val, ok := contract.Call("getState")[0].(uint64)
+	if !ok {
+		fmt.Printf("expected uint64")
+		os.Exit(1)
+	}
 	if val != 1 {
 		fmt.Printf("expected 1")
 		os.Exit(1)

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -121,6 +121,10 @@ func (c *Contract) Call(methodName string) []interface{} {
 	return results
 }
 
+func (c *Contract) Raw() *sdk.Contract {
+	return c.Contract
+}
+
 func (c *Contract) SendTransaction(method string, args []interface{}, confidentialBytes []byte) *types.Receipt {
 	txnResult, err := c.Contract.SendTransaction(method, args, confidentialBytes)
 	if err != nil {


### PR DESCRIPTION
Before, changing a state variable was a void operation and the confidential request did not fail, but now it raises an error and it fails. The test runner has been changed to account for that.