### PR TITLE
Use flashbots/suave-toolchain action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,22 +62,12 @@ jobs:
         with:
           submodules: "true"
 
-      - name: Checkout suave-geth repo
-        uses: actions/checkout@v4
-        with:
-          repository: flashbots/suave-geth
-          path: suave-geth
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Build suave
-        run: |
-          cd suave-geth
-          make geth
+      - name: Install suave-geth
+        uses: flashbots/suave-toolchain@v0.1
 
       - name: Run suave
         run: |
-          ./suave-geth/build/bin/geth --suave.dev --suave.eth.external-whitelist localhost:1234 &
+          suave-geth --suave.dev --suave.eth.external-whitelist localhost:1234 &
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
This PR uses the `flashbots/suave-toolchain` action to install `suave-geth`.