### PR TITLE
Enable examples on public networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+export KETTLE_PRIVKEY=
+export KETTLE_RPC=
+export L1_PRIVKEY=
+export L1_RPC=
+export BUILDER_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 out/
 cache/
+.env

--- a/examples/app-ofa-private/README.md
+++ b/examples/app-ofa-private/README.md
@@ -1,4 +1,3 @@
-
 # Example Suapp for an OFA application with private transactions
 
 This example features an [Order flow auction](https://collective.flashbots.net/t/order-flow-auctions-and-centralisation-ii-order-flow-auctions/284) Suapp based on the [mev-share](https://github.com/flashbots/mev-share) protocol specification.
@@ -10,7 +9,8 @@ User transactions are stored in the confidential datastore and only a small hint
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ cd ../..
+$ docker-compose up
 ```
 
 Execute the deployment script:

--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 type config struct {
-	RelayerURL string `env:"RELAYER_URL, default=local"`
+	BuilderURL string `env:"BUILDER_URL, default=local"`
 }
 
 func main() {
@@ -26,10 +26,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if cfg.RelayerURL == "local" {
+	if cfg.BuilderURL == "local" {
 		// '172.17.0.1' is the default docker host IP that a docker container can
 		// use to connect with a service running on the host machine.
-		cfg.RelayerURL = "http://172.17.0.1:1234"
+		cfg.BuilderURL = "http://172.17.0.1:1234"
 
 		go func() {
 			log.Fatal(http.ListenAndServe("0.0.0.0:1234", &relayHandlerExample{}))
@@ -127,7 +127,7 @@ func main() {
 	// Step 4. Emit the batch to the relayer and parse the output
 	fmt.Println("4. Emit batch")
 
-	receipt = contract.SendTransaction("emitMatchDataRecordAndHint", []interface{}{cfg.RelayerURL, matchEvent.DataRecordId}, backRunBundleBytes)
+	receipt = contract.SendTransaction("emitMatchDataRecordAndHint", []interface{}{cfg.BuilderURL, matchEvent.DataRecordId}, backRunBundleBytes)
 	bundleHash, err := decodeBundleEmittedOutput(receipt)
 	if err != nil {
 		log.Fatal(err)

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -84,7 +84,7 @@ func (p *PrivKey) MarshalPrivKey() []byte {
 func (p *PrivKey) UnmarshalText(text []byte) error {
 	key, err := crypto.HexToECDSA(string(text))
 	if err != nil {
-		return fmt.Errorf("failed to parse private key: %v", err)
+		return fmt.Errorf("failed to parse private key: %w", err)
 	}
 	p.Priv = key
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/ethereum/go-ethereum => github.com/flashbots/suave-geth v0.0.
 
 require (
 	github.com/ethereum/go-ethereum v0.0.0-00010101000000-000000000000
+	github.com/sethvargo/go-envconfig v1.0.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flashbots/suapp-examples
 
 go 1.21.3
 
-replace github.com/ethereum/go-ethereum => github.com/flashbots/suave-geth v0.0.0-20240103141237-95ae32eaaccb
+replace github.com/ethereum/go-ethereum => github.com/flashbots/suave-geth v0.1.1-0.20240116112006-29dd186e4608
 
 require (
 	github.com/ethereum/go-ethereum v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/flashbots/go-boost-utils v1.7.0 h1:BaLeGl71nD/ro0aUzCYqHc8PiqIIaErLwc
 github.com/flashbots/go-boost-utils v1.7.0/go.mod h1:1Y0rD/e57KZZIRgkCcXRvvztW+v+eZHnWu25wxtGstU=
 github.com/flashbots/go-utils v0.4.13-0.20230919094729-c049be707f79 h1:y2obQCUIvqKISLxWxC0Tz8Oc618vA3q1xmn9GwElvfI=
 github.com/flashbots/go-utils v0.4.13-0.20230919094729-c049be707f79/go.mod h1:LauDwifaRdSK0mS5X34GR59pJtUu1T/lOFNdff1BqtI=
-github.com/flashbots/suave-geth v0.0.0-20240103141237-95ae32eaaccb h1:nm42W76MwJVn1rgI3sHE1RaVJrR1U34Kx61quBd1QbU=
-github.com/flashbots/suave-geth v0.0.0-20240103141237-95ae32eaaccb/go.mod h1:FSIekwR5M+o2lAXumvYR+E+RYgQ0yK3X8HdRMSTdagU=
+github.com/flashbots/suave-geth v0.1.1-0.20240116112006-29dd186e4608 h1:9+xpTpP49bdjql38/6I68aZQ1dejn8CoQgt5IIoCFOw=
+github.com/flashbots/suave-geth v0.1.1-0.20240116112006-29dd186e4608/go.mod h1:FSIekwR5M+o2lAXumvYR+E+RYgQ0yK3X8HdRMSTdagU=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=


### PR DESCRIPTION
This PR modifies the framework so that the examples can be run on public networks. The configuration parameters (rpc endpoints, funded private keys) can be set with env variables. By default, if nothing is set, the parameters are hardcoded with values from the local devnet.
The env variables are:
- `KETTLE_PRIVKEY`: Funded private key in the Suave network.
- `KETTLE_RPC`: Rpc of the kettle. (i.e. `https://rpc.rigil.suave.flashbots.net`).
- `L1_PRIVKEY`: Funded private key for the suave-enabled node network.
- `L1_RPC`: Rpc of the suave-enabled node (i.e. `http://goerli.rigil.suave.flashbots.net:8545`)
- `RELAYER_URL`: Url of the relayer to send bundles. (i.e. `https://relay-goerli.flashbots.net`). This is only required for the `app-ofa-example`.

Requires https://github.com/flashbots/suave-geth/pull/159