### PR TITLE
Update to upstream suave-std

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   suave-mevm:
-    image: flashbots/suave-geth:latest
+    image: flashbots/suave-geth:v0.1.2
     command:
       - --suave.dev
       - --http.addr=0.0.0.0

--- a/examples/app-ofa-private/ofa-private.sol
+++ b/examples/app-ofa-private/ofa-private.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.8;
 
 import "suave-std/suavelib/Suave.sol";
+import "suave-std/Context.sol";
 
 contract OFAPrivate {
     // Struct to hold hint-related information for an order.
@@ -15,9 +16,9 @@ contract OFAPrivate {
     event BundleEmitted(string bundleRawResponse);
 
     // Internal function to save order details and generate a hint.
-    function saveOrder(uint64 decryptionCondition) internal view returns (HintOrder memory) {
+    function saveOrder(uint64 decryptionCondition) internal returns (HintOrder memory) {
         // Retrieve the bundle data from the confidential inputs
-        bytes memory bundleData = Suave.confidentialInputs();
+        bytes memory bundleData = Context.confidentialInputs();
 
         // Simulate the bundle and extract its score.
         uint64 egp = Suave.simulateBundle(bundleData);
@@ -42,22 +43,18 @@ contract OFAPrivate {
         return hintOrder;
     }
 
-    function emitHint(HintOrder memory order) public payable {
+    function emitHint(HintOrder memory order) public {
         emit HintEvent(order.id, order.hint);
     }
 
     // Function to create a new user order
-    function newOrder(uint64 decryptionCondition) external payable returns (bytes memory) {
+    function newOrder(uint64 decryptionCondition) external returns (bytes memory) {
         HintOrder memory hintOrder = saveOrder(decryptionCondition);
         return abi.encodeWithSelector(this.emitHint.selector, hintOrder);
     }
 
     // Function to match and backrun another dataRecord.
-    function newMatch(Suave.DataId shareDataRecordId, uint64 decryptionCondition)
-        external
-        payable
-        returns (bytes memory)
-    {
+    function newMatch(Suave.DataId shareDataRecordId, uint64 decryptionCondition) external returns (bytes memory) {
         HintOrder memory hintOrder = saveOrder(decryptionCondition);
 
         // Merge the dataRecords and store them in the confidential datastore.
@@ -70,13 +67,12 @@ contract OFAPrivate {
         return abi.encodeWithSelector(this.emitHint.selector, hintOrder);
     }
 
-    function emitMatchDataRecordAndHintCallback(string memory bundleRawResponse) external payable {
+    function emitMatchDataRecordAndHintCallback(string memory bundleRawResponse) external {
         emit BundleEmitted(bundleRawResponse);
     }
 
     function emitMatchDataRecordAndHint(string memory builderUrl, Suave.DataId dataRecordId)
         external
-        payable
         returns (bytes memory)
     {
         bytes memory bundleData = Suave.fillMevShareBundle(dataRecordId);
@@ -85,7 +81,7 @@ contract OFAPrivate {
         return abi.encodeWithSelector(this.emitMatchDataRecordAndHintCallback.selector, response);
     }
 
-    function submitBundle(string memory builderUrl, bytes memory bundleData) internal view returns (bytes memory) {
+    function submitBundle(string memory builderUrl, bytes memory bundleData) internal returns (bytes memory) {
         // encode the jsonrpc request in JSON format.
         bytes memory body =
             abi.encodePacked('{"jsonrpc":"2.0","method":"mev_sendBundle","params":[', bundleData, '],"id":1}');

--- a/examples/mevm-confidential-store/confidential-store.sol
+++ b/examples/mevm-confidential-store/confidential-store.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.8;
 import "suave-std/suavelib/Suave.sol";
 
 contract ConfidentialStore {
-    function callback() external payable {}
+    function callback() external {}
 
-    function example() external payable returns (bytes memory) {
+    function example() external returns (bytes memory) {
         address[] memory allowedList = new address[](1);
         allowedList[0] = address(this);
 

--- a/examples/mevm-external-uniswap-v3-quote/external-uniswap-v3-quote.sol
+++ b/examples/mevm-external-uniswap-v3-quote/external-uniswap-v3-quote.sol
@@ -19,7 +19,7 @@ library UniswapV3 {
         uint160 sqrtPriceLimitX96;
     }
 
-    function exactOutputSingle(ExactOutputSingleParams memory params) internal view returns (uint256 amountIn) {
+    function exactOutputSingle(ExactOutputSingleParams memory params) internal returns (uint256 amountIn) {
         bytes memory output = Suave.ethcall(swapRouter, abi.encodeWithSignature(exactOutputSingleSig, params));
         uint256 num = abi.decode(output, (uint64));
         return num;
@@ -29,7 +29,7 @@ library UniswapV3 {
 contract ExternalUniswapV3Quote {
     function callback() external payable {}
 
-    function example(UniswapV3.ExactOutputSingleParams memory params) external payable returns (bytes memory) {
+    function example(UniswapV3.ExactOutputSingleParams memory params) external returns (bytes memory) {
         UniswapV3.exactOutputSingle(params);
 
         return abi.encodeWithSelector(this.callback.selector);

--- a/examples/mevm-is-confidential/is-confidential.sol
+++ b/examples/mevm-is-confidential/is-confidential.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.8;
 import "suave-std/suavelib/Suave.sol";
 
 contract IsConfidential {
-    function callback() external payable {}
+    function callback() external {}
 
-    function example() external payable returns (bytes memory) {
+    function example() external returns (bytes memory) {
         require(Suave.isConfidential());
 
         return abi.encodeWithSelector(this.callback.selector);

--- a/examples/onchain-callback/onchain-callback.sol
+++ b/examples/onchain-callback/onchain-callback.sol
@@ -12,7 +12,7 @@ contract OnChainCallback {
         emit CallbackEvent(num);
     }
 
-    function example() external payable returns (bytes memory) {
+    function example() external returns (bytes memory) {
         // event emitted in the off-chain confidential context, no effect.
         emit NilEvent();
 

--- a/examples/onchain-state/onchain-state.sol
+++ b/examples/onchain-state/onchain-state.sol
@@ -6,15 +6,15 @@ import "suave-std/suavelib/Suave.sol";
 contract OnChainState {
     uint64 state;
 
-    function nilExampleCallback() external payable {}
+    function nilExampleCallback() external {}
 
-    function getState() external returns (uint64) {
+    function getState() external view returns (uint64) {
         return state;
     }
 
     // nilExample is a function executed in a confidential request
     // that CANNOT modify the state of the smart contract.
-    function nilExample() external payable returns (bytes memory) {
+    function nilExample() external returns (bytes memory) {
         require(Suave.isConfidential());
         state++;
         return abi.encodeWithSelector(this.nilExampleCallback.selector);
@@ -26,7 +26,7 @@ contract OnChainState {
 
     // example is a function executed in a confidential request that includes
     // a callback that can modify the state.
-    function example() external payable returns (bytes memory) {
+    function example() external returns (bytes memory) {
         require(Suave.isConfidential());
         return bytes.concat(this.exampleCallback.selector);
     }

--- a/examples/private-library-confidential-store/lib-confidential-store.sol
+++ b/examples/private-library-confidential-store/lib-confidential-store.sol
@@ -1,16 +1,18 @@
+// SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.8;
 
 import "suave-std/suavelib/Suave.sol";
+import "suave-std/Context.sol";
 
 contract PublicSuapp {
     event ContractRegistered(Suave.DataId dataId);
 
-    function registerContractCallback(Suave.DataId dataId) public payable {
+    function registerContractCallback(Suave.DataId dataId) public {
         emit ContractRegistered(dataId);
     }
 
-    function registerContract() public payable returns (bytes memory) {
-        bytes memory bytecode = Suave.confidentialInputs();
+    function registerContract() public returns (bytes memory) {
+        bytes memory bytecode = Context.confidentialInputs();
 
         address[] memory allowedList = new address[](1);
         allowedList[0] = address(this);
@@ -23,7 +25,7 @@ contract PublicSuapp {
 
     function exampleCallback() public {}
 
-    function example(Suave.DataId dataId) public payable returns (bytes memory) {
+    function example(Suave.DataId dataId) public returns (bytes memory) {
         bytes memory bytecode = Suave.confidentialRetrieve(dataId, "bytecode");
         address addr = deploy(bytecode);
 

--- a/examples/private-library/private-library.sol
+++ b/examples/private-library/private-library.sol
@@ -1,12 +1,14 @@
+// SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.8;
 
 import "suave-std/suavelib/Suave.sol";
+import "suave-std/Context.sol";
 
 contract PublicSuapp {
-    function callback() public payable {}
+    function callback() public {}
 
-    function example() public payable returns (bytes memory) {
-        bytes memory bytecode = Suave.confidentialInputs();
+    function example() public returns (bytes memory) {
+        bytes memory bytecode = Context.confidentialInputs();
         address addr = deploy(bytecode);
 
         PrivateLibraryI c = PrivateLibraryI(addr);

--- a/examples/std-transaction-signing/transaction-signing.sol
+++ b/examples/std-transaction-signing/transaction-signing.sol
@@ -1,19 +1,21 @@
+// SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.8;
 
 import "suave-std/suavelib/Suave.sol";
 import "suave-std/Transactions.sol";
+import "suave-std/Context.sol";
 
 contract TransactionSigning {
     using Transactions for *;
 
     event TxnSignature(bytes32 r, bytes32 s);
 
-    function callback(bytes32 r, bytes32 s) public payable {
+    function callback(bytes32 r, bytes32 s) public {
         emit TxnSignature(r, s);
     }
 
-    function example() public payable returns (bytes memory) {
-        string memory signingKey = string(Suave.confidentialInputs());
+    function example() public returns (bytes memory) {
+        string memory signingKey = string(Context.confidentialInputs());
 
         Transactions.EIP155Request memory txnWithToAddress = Transactions.EIP155Request({
             to: address(0x00000000000000000000000000000000DeaDBeef),

--- a/examples/uniswap-v2-intents-goerli/contracts/Intents.sol
+++ b/examples/uniswap-v2-intents-goerli/contracts/Intents.sol
@@ -79,7 +79,7 @@ contract Intents {
     }
 
     /// Broadcast an intent to SUAVE.
-    function sendIntent() public view returns (bytes memory suaveCallData) {
+    function sendIntent() public returns (bytes memory suaveCallData) {
         // ensure we're computing in the enclave
         require(Suave.isConfidential(), "not confidential");
 
@@ -141,7 +141,6 @@ contract Intents {
     /// ]
     function fulfillIntent(bytes32 orderId, Suave.DataId dataId, TxMeta memory txMeta)
         public
-        view
         returns (bytes memory suaveCallData)
     {
         // ensure we're computing in the enclave (is this required here?)

--- a/examples/uniswap-v2-intents-goerli/contracts/libraries/SwopLib.sol
+++ b/examples/uniswap-v2-intents-goerli/contracts/libraries/SwopLib.sol
@@ -31,11 +31,7 @@ library UniV2Swop {
     address public constant router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
 
     /// Returns market price sans fees.
-    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
-        internal
-        view
-        returns (uint256 price)
-    {
+    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) internal returns (uint256 price) {
         bytes memory result = Suave.ethcall(
             router, abi.encodeWithSignature("getAmountOut(uint256,uint256,uint256)", amountIn, reserveIn, reserveOut)
         );
@@ -44,7 +40,6 @@ library UniV2Swop {
 
     function approve(address token, address spender, uint256 amount, bytes32 privateKey, TxMeta memory txMeta)
         internal
-        view
         returns (bytes memory signedTx, bytes memory data)
     {
         data = abi.encodeWithSignature("approve(address,uint256)", spender, amount);
@@ -70,7 +65,7 @@ library UniV2Swop {
         SwapExactTokensForTokensRequest memory request,
         bytes32 privateKey,
         TxMeta memory txMeta
-    ) internal view returns (bytes memory signedTx, bytes memory data) {
+    ) internal returns (bytes memory signedTx, bytes memory data) {
         data = abi.encodeWithSignature(
             "swapExactTokensForTokens(uint256,uint256,address[],address,uint256)",
             request.amountIn,


### PR DESCRIPTION
This PR updates the suapp-examples to the latest `suave-std` version, it introduces two changes:
- Functions are not `view` anymore.
- It uses the new `Context.confidentialInputs()` function instead of the precompile.