### PR TITLE
Add flag to enable L1

### DIFF
--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -36,7 +36,7 @@ func main() {
 		}()
 	}
 
-	fr := framework.New()
+	fr := framework.New(framework.WithL1())
 	contract := fr.Suave.DeployContract("ofa-private.sol/OFAPrivate.json")
 
 	// Step 1. Create and fund the accounts we are going to frontrun/backrun


### PR DESCRIPTION
This PR introduces the Option pattern to configure the test framework. It introduces the option `WithL1` to select whether or not to enable the l1 integration (i.e. ping the default L1 node). This is useful because many of the examples do not require an L1 but as it is right now you need one running for the framework to work. 