### PR TITLE
Rename sendTransaction to sendConfidentialRequest

### DIFF
--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -90,7 +90,7 @@ func main() {
 	log.Printf("Latest goerli block: %d", target)
 
 	// new dataRecord inputs
-	receipt := contract.SendTransaction("newOrder", []interface{}{target + 1}, bundleBytes)
+	receipt := contract.SendConfidentialRequest("newOrder", []interface{}{target + 1}, bundleBytes)
 
 	hintEvent := &HintEvent{}
 	if err := hintEvent.Unpack(receipt.Logs[0]); err != nil {
@@ -115,7 +115,7 @@ func main() {
 	log.Printf("Latest goerli block: %d", target)
 
 	// backrun inputs
-	receipt = contract.SendTransaction("newMatch", []interface{}{hintEvent.DataRecordId, target + 1}, backRunBundleBytes)
+	receipt = contract.SendConfidentialRequest("newMatch", []interface{}{hintEvent.DataRecordId, target + 1}, backRunBundleBytes)
 
 	matchEvent := &HintEvent{}
 	if err := matchEvent.Unpack(receipt.Logs[0]); err != nil {
@@ -127,7 +127,7 @@ func main() {
 	// Step 4. Emit the batch to the relayer and parse the output
 	fmt.Println("4. Emit batch")
 
-	receipt = contract.SendTransaction("emitMatchDataRecordAndHint", []interface{}{cfg.BuilderURL, matchEvent.DataRecordId}, backRunBundleBytes)
+	receipt = contract.SendConfidentialRequest("emitMatchDataRecordAndHint", []interface{}{cfg.BuilderURL, matchEvent.DataRecordId}, backRunBundleBytes)
 	bundleHash, err := decodeBundleEmittedOutput(receipt)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/build-eth-block/main.go
+++ b/examples/build-eth-block/main.go
@@ -48,8 +48,8 @@ func main() {
 		decryptionCondition := targetBlock + 1
 		allowedPeekers := []common.Address{
 			buildEthBlockAddress,
-			bundleContract.Address(),
-			ethBlockContract.Address()}
+			bundleContract.Raw().Address(),
+			ethBlockContract.Raw().Address()}
 		allowedStores := []common.Address{}
 		newBundleArgs := []any{
 			decryptionCondition,
@@ -59,7 +59,7 @@ func main() {
 		confidentialDataBytes, err := bundleContract.Abi.Methods["fetchConfidentialBundleData"].Outputs.Pack(bundleBytes)
 		maybe(err)
 
-		_ = bundleContract.SendTransaction("newBundle", newBundleArgs, confidentialDataBytes)
+		_ = bundleContract.SendConfidentialRequest("newBundle", newBundleArgs, confidentialDataBytes)
 	}
 
 	{ // Signal to the builder that it's time to build a new block
@@ -69,7 +69,7 @@ func main() {
 			FeeRecipient:   common.Address{0x42},
 		}
 
-		_ = ethBlockContract.SendTransaction("buildFromPool", []any{payloadArgsTuple, targetBlock + 1}, nil)
+		_ = ethBlockContract.SendConfidentialRequest("buildFromPool", []any{payloadArgsTuple, targetBlock + 1}, nil)
 		maybe(err)
 	}
 }

--- a/examples/mevm-confidential-store/main.go
+++ b/examples/mevm-confidential-store/main.go
@@ -6,5 +6,6 @@ import (
 
 func main() {
 	fr := framework.New()
-	fr.Suave.DeployContract("confidential-store.sol/ConfidentialStore.json").SendTransaction("example", []interface{}{}, nil)
+	fr.Suave.DeployContract("confidential-store.sol/ConfidentialStore.json").
+		SendConfidentialRequest("example", []interface{}{}, nil)
 }

--- a/examples/mevm-context/main.go
+++ b/examples/mevm-context/main.go
@@ -7,5 +7,5 @@ import (
 func main() {
 	fr := framework.New()
 	fr.Suave.DeployContract("context.sol/ContextExample.json").
-		SendTransaction("example", nil, []byte{0x1})
+		SendConfidentialRequest("example", nil, []byte{0x1})
 }

--- a/examples/mevm-is-confidential/main.go
+++ b/examples/mevm-is-confidential/main.go
@@ -7,5 +7,5 @@ import (
 func main() {
 	fr := framework.New()
 	fr.Suave.DeployContract("is-confidential.sol/IsConfidential.json").
-		SendTransaction("example", nil, nil)
+		SendConfidentialRequest("example", nil, nil)
 }

--- a/examples/offchain-logs/main.go
+++ b/examples/offchain-logs/main.go
@@ -10,13 +10,13 @@ func main() {
 	fr := framework.New()
 	contract := fr.Suave.DeployContract("offchain-logs.sol/OffchainLogs.json")
 
-	receipt := contract.SendTransaction("example", nil, nil)
+	receipt := contract.SendConfidentialRequest("example", nil, nil)
 	if len(receipt.Logs) != 2 {
 		log.Fatal("two logs expected")
 	}
 
 	// emit the CCR but DO NOT leak the logs
-	receipt = contract.SendTransaction("exampleNoLogs", nil, nil)
+	receipt = contract.SendConfidentialRequest("exampleNoLogs", nil, nil)
 	if len(receipt.Logs) != 1 {
 		log.Fatal("only one log expected")
 	}

--- a/examples/onchain-callback/main.go
+++ b/examples/onchain-callback/main.go
@@ -7,5 +7,5 @@ import (
 func main() {
 	fr := framework.New()
 	fr.Suave.DeployContract("onchain-callback.sol/OnChainCallback.json").
-		SendTransaction("example", nil, nil)
+		SendConfidentialRequest("example", nil, nil)
 }

--- a/examples/onchain-state/main.go
+++ b/examples/onchain-state/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	fmt.Println("2. Send a confidential request that modifies the state")
 
-	contract.SendTransaction("example", nil, nil)
+	contract.SendConfidentialRequest("example", nil, nil)
 	val, ok := contract.Call("getState")[0].(uint64)
 	if !ok {
 		fmt.Printf("expected uint64")

--- a/examples/private-library-confidential-store/main.go
+++ b/examples/private-library-confidential-store/main.go
@@ -12,12 +12,12 @@ func main() {
 	suapp := fr.Suave.DeployContract("lib-confidential-store.sol/PublicSuapp.json")
 
 	// Deploy the contract and get the bid id
-	receipt := suapp.SendTransaction("registerContract", nil, privateLibrary.Code)
+	receipt := suapp.SendConfidentialRequest("registerContract", nil, privateLibrary.Code)
 	event, _ := contractRegisteredABI.Inputs.Unpack(receipt.Logs[0].Data)
 	privateContractBidId := event[0].([16]byte)
 
 	// Use the private contract
-	suapp.SendTransaction("example", []interface{}{privateContractBidId}, nil)
+	suapp.SendConfidentialRequest("example", []interface{}{privateContractBidId}, nil)
 }
 
 var contractRegisteredABI abi.Event

--- a/examples/private-library/main.go
+++ b/examples/private-library/main.go
@@ -7,5 +7,5 @@ func main() {
 
 	fr := framework.New()
 	fr.Suave.DeployContract("private-library.sol/PublicSuapp.json").
-		SendTransaction("example", nil, privateLibrary.Code)
+		SendConfidentialRequest("example", nil, privateLibrary.Code)
 }

--- a/examples/std-transaction-signing/main.go
+++ b/examples/std-transaction-signing/main.go
@@ -12,7 +12,7 @@ func main() {
 	priv := "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
 
 	contract := fr.Suave.DeployContract("transaction-signing.sol/TransactionSigning.json")
-	receipt := contract.SendTransaction("example", nil, []byte(priv))
+	receipt := contract.SendConfidentialRequest("example", nil, []byte(priv))
 
 	// validate the signature
 	txnSignatureEvent, err := contract.Abi.Events["TxnSignature"].ParseLog(receipt.Logs[0])

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -107,7 +107,7 @@ func GeneratePrivKey() *PrivKey {
 }
 
 type Contract struct {
-	*sdk.Contract
+	contract *sdk.Contract
 
 	clt        *sdk.Client
 	kettleAddr common.Address
@@ -139,14 +139,14 @@ func (c *Contract) Call(methodName string) []interface{} {
 }
 
 func (c *Contract) Raw() *sdk.Contract {
-	return c.Contract
+	return c.contract
 }
 
 var executionRevertedPrefix = "execution reverted: 0x"
 
-// SendTransaction sends the transaction and panics if it fails
-func (c *Contract) SendTransaction(method string, args []interface{}, confidentialBytes []byte) *types.Receipt {
-	txnResult, err := c.Contract.SendTransaction(method, args, confidentialBytes)
+// SendConfidentialRequest sends the confidential request to the kettle
+func (c *Contract) SendConfidentialRequest(method string, args []interface{}, confidentialBytes []byte) *types.Receipt {
+	txnResult, err := c.contract.SendTransaction(method, args, confidentialBytes)
 	if err != nil {
 		// decode the PeekerReverted error
 		errMsg := err.Error()
@@ -276,7 +276,7 @@ func (c *Chain) DeployContract(path string) *Contract {
 	log.Printf("deployed contract at %s", receipt.ContractAddress.Hex())
 
 	contract := sdk.GetContract(receipt.ContractAddress, artifact.Abi, c.clt)
-	return &Contract{addr: receipt.ContractAddress, clt: c.clt, kettleAddr: c.kettleAddr, Abi: artifact.Abi, Contract: contract}
+	return &Contract{addr: receipt.ContractAddress, clt: c.clt, kettleAddr: c.kettleAddr, Abi: artifact.Abi, contract: contract}
 }
 
 func (c *Contract) Ref(acct *PrivKey) *Contract {
@@ -285,7 +285,7 @@ func (c *Contract) Ref(acct *PrivKey) *Contract {
 	cc := &Contract{
 		addr:     c.addr,
 		Abi:      c.Abi,
-		Contract: sdk.GetContract(c.addr, c.Abi, clt),
+		contract: sdk.GetContract(c.addr, c.Abi, clt),
 	}
 	return cc
 }


### PR DESCRIPTION
This PR renames the `SendTransaction` method to `SendConfidentialRequest` because a confidential request is not a transaction.