### PR TITLE
Fix app ofa example

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,6 +69,10 @@ jobs:
         run: |
           make devnet-up
 
+      - name: Debug image names
+        run: |
+          docker images
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.21
+          go-version: ^1.22
         id: go
 
       - name: Check out code into the Go module directory and submodules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run suave
         run: |
-          docker-compose up -d
+          make devnet-up
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,14 @@ lt: lint test
 
 .PHONY: devnet-up
 devnet-up:
+	@docker compose --file ./docker-compose.yaml up --detach
+
+.PHONY: devnet-down
+devnet-down:
+	@docker compose --file ./docker-compose.yaml down
+
+.PHONY: devnet-kurtosis-up
+devnet-kurtosis-up:
 	@kurtosis run \
 			--enclave eth-devnet \
 		github.com/kurtosis-tech/ethereum-package@1.4.0 \
@@ -35,8 +43,8 @@ devnet-up:
 	@kurtosis service stop eth-devnet mev-flood
 	@docker compose --file ./devnet/docker-compose.yaml up --detach
 
-.PHONY: devnet-down
-devnet-down:
+.PHONY: devnet-kurtosis-down
+devnet-kurtosis-down:
 	@docker compose --file ./devnet/docker-compose.yaml down
 	@docker volume rm devnet_suave-blockscout-db-data || true
 	@kurtosis enclave stop eth-devnet
@@ -46,6 +54,7 @@ devnet-down:
 .PHONY: run-integration
 run-integration:
 	go run examples/build-eth-block/main.go
+	go run examples/app-ofa-example/main.go
 	go run examples/mevm-confidential-store/main.go
 	go run examples/mevm-context/main.go
 	go run examples/mevm-is-confidential/main.go

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ devnet-kurtosis-down:
 .PHONY: run-integration
 run-integration:
 	go run examples/build-eth-block/main.go
-	go run examples/app-ofa-example/main.go
+	go run examples/app-ofa-private/main.go
 	go run examples/mevm-confidential-store/main.go
 	go run examples/mevm-context/main.go
 	go run examples/mevm-is-confidential/main.go

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   suave-mevm:
-    image: flashbots/suave-geth:v0.1.4
+    image: flashbots/suave-geth:latest
     command:
       - --suave.dev
       - --http.addr=0.0.0.0
@@ -15,7 +15,7 @@ services:
     networks:
       - suave-net
   suave-enabled-chain:
-    image: flashbots/suave-execution-geth:v0.0.1-alpha.1-dev-03
+    image: flashbots/suave-execution-geth:latest
     command:
       - --dev
       - --dev.gaslimit=30000000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   suave-mevm:
-    image: flashbots/suave-geth:latest
+    image: flashbots/suave-geth:v0.1.4
     command:
       - --suave.dev
       - --http.addr=0.0.0.0
@@ -15,7 +15,7 @@ services:
     networks:
       - suave-net
   suave-enabled-chain:
-    image: flashbots/suave-execution-geth:latest
+    image: flashbots/suave-execution-geth:v0.0.1-alpha.1-dev-03
     command:
       - --dev
       - --dev.gaslimit=30000000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - --suave.dev
       - --http.addr=0.0.0.0
       - --suave.eth.remote_endpoint=http://suave-enabled-chain:8545
-      - --suave.eth.external-whitelist=172.17.0.1
+      - --suave.eth.external-whitelist=*
     depends_on:
       - suave-enabled-chain
     ports:

--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -29,7 +29,7 @@ func main() {
 	if cfg.BuilderURL == "local" {
 		// 'host.docker.internal' is the default docker host IP that a docker container can
 		// use to connect with a service running on the host machine.
-		cfg.BuilderURL = "http://172.17.0.1:1234"
+		cfg.BuilderURL = "http://" + framework.GatewayAddr() + ":1234"
 
 		go func() {
 			log.Fatal(http.ListenAndServe("0.0.0.0:1234", &relayHandlerExample{}))

--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -29,7 +29,7 @@ func main() {
 	if cfg.BuilderURL == "local" {
 		// 'host.docker.internal' is the default docker host IP that a docker container can
 		// use to connect with a service running on the host machine.
-		cfg.BuilderURL = "http://host.docker.internal:1234"
+		cfg.BuilderURL = "http://172.17.0.1:1234"
 
 		go func() {
 			log.Fatal(http.ListenAndServe("0.0.0.0:1234", &relayHandlerExample{}))

--- a/examples/app-ofa-private/main.go
+++ b/examples/app-ofa-private/main.go
@@ -27,9 +27,9 @@ func main() {
 	}
 
 	if cfg.BuilderURL == "local" {
-		// '172.17.0.1' is the default docker host IP that a docker container can
+		// 'host.docker.internal' is the default docker host IP that a docker container can
 		// use to connect with a service running on the host machine.
-		cfg.BuilderURL = "http://172.17.0.1:1234"
+		cfg.BuilderURL = "http://host.docker.internal:1234"
 
 		go func() {
 			log.Fatal(http.ListenAndServe("0.0.0.0:1234", &relayHandlerExample{}))

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -338,3 +338,13 @@ func (c *Chain) FundAccount(to common.Address, value *big.Int) error {
 	}
 	return nil
 }
+
+// GatewayAddr returns the IP address of the Docker gateway. This is,
+// the IP address to access the host machine.
+func GatewayAddr() string {
+	if os.Getenv("CI") == "true" {
+		// Inside Github actions, the 'host.docker.internal' does not seem to work.
+		return "172.17.0.1"
+	}
+	return "host.docker.internal"
+}


### PR DESCRIPTION
This PR fixes the `app-ofa-example`. The external IP used in the example to mock the relay was not accessible inside the Docker container for the MEVM.