### PR TITLE
Remove incorrect env variables from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ forge build
     # Launch kurtosis devnet + sidecar docker-compose with SUAVE
     make devnet-up
 
-    # Point SUAVE examples to the devnet
-    export BUILDER_URL=http://el-4-geth-builder-lighthouse:8545
-    export L1_PRIVKEY=bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31
-
     # Run
     go run examples/app-ofa-private/main.go
 


### PR DESCRIPTION
Fixes https://github.com/flashbots/suapp-examples/issues/56

Removing the environment variables works, the alternative is setting them to correct values. The L1 private key correct value is the default one:
```
export L1_PRIVKEY=6c45335a22461ccdb978b78ab61b238bad2fae4544fb55c14eb096c875ccfc52
```
But I don't know what the `BUILDER_URL` should be. Setting it to `http://host.docker.internal:1234` does not work.
