### PR TITLE
Add private swap example

### DIFF
--- a/examples/private-token-swap/L1/src/pool.sol
+++ b/examples/private-token-swap/L1/src/pool.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.8;
+
+contract Pool {
+    event Swap(address from, address to, uint256 amount, uint256 resultAmount);
+
+    function swap(address from, address to, uint256 amount) external returns (uint256) {
+        // some swap logic
+        emit Swap(from, to, amount, amount * 2);
+        return amount * 2;
+    }
+}

--- a/examples/private-token-swap/README.md
+++ b/examples/private-token-swap/README.md
@@ -1,0 +1,17 @@
+# Example Suapp with private token Swap
+
+Example showcasing how a Suapp can be used for creating private swaps in liquidity pools protecting users from sandwich attacks or any other kind of frontrunning / backrunning attack.
+
+## How to use
+
+Run `Suave` in development mode:
+
+```
+$ suave --suave.dev
+```
+
+Execute the script:
+
+```
+$ go run main.go
+```

--- a/examples/private-token-swap/SUAVE/src/private-swap.sol
+++ b/examples/private-token-swap/SUAVE/src/private-swap.sol
@@ -11,15 +11,21 @@ interface Pool {
 }
 
 contract PrivateSwap is Suapp {
-    function callback() external payable emitOffchainLogs {}
+    Gateway private gateway;
 
     event Swap(address from, address to, uint256 amount, uint256 resultAmount);
 
-    function example(address lp) external returns (bytes memory) {
+    constructor(string memory jsonrpc, address lp) {
+        gateway = new Gateway(jsonrpc, lp);
+    }
+
+    function callback() external payable emitOffchainLogs {}
+
+    function example() external returns (bytes memory) {
         bytes memory confidentialInputs = Context.confidentialInputs();
         (address from, address to, uint256 amount) = abi.decode(confidentialInputs, (address, address, uint256));
 
-        Pool pool = Pool(address(lp));
+        Pool pool = Pool(address(gateway));
 
         uint256 resultAmount = pool.swap(from, to, amount);
         emit Swap(from, to, amount, resultAmount);

--- a/examples/private-token-swap/SUAVE/src/private-swap.sol
+++ b/examples/private-token-swap/SUAVE/src/private-swap.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.8;
+
+import "suave-std/Gateway.sol";
+import "suave-std/Suapp.sol";
+import "suave-std/Context.sol";
+
+interface Pool {
+    // swap (token from, token to, amount)
+    function swap(address, address, uint256) external returns (uint256);
+}
+
+contract PrivateSwap is Suapp {
+    function callback() external payable emitOffchainLogs {}
+
+    event Swap(address from, address to, uint256 amount, uint256 resultAmount);
+
+    function example(address lp) external returns (bytes memory) {
+        bytes memory confidentialInputs = Context.confidentialInputs();
+        (address from, address to, uint256 amount) = abi.decode(confidentialInputs, (address, address, uint256));
+
+        Pool pool = Pool(address(lp));
+
+        uint256 resultAmount = pool.swap(from, to, amount);
+        emit Swap(from, to, amount, resultAmount);
+
+        return abi.encodeWithSelector(this.callback.selector);
+    }
+}

--- a/examples/private-token-swap/main.go
+++ b/examples/private-token-swap/main.go
@@ -14,8 +14,9 @@ func main() {
 	// deploy some example pool contract with swap function
 	poolContract := fr.L1.DeployContract("pool.sol/Pool.json")
 	lpAddress := poolContract.Raw().Address()
+	l1RPCInternalURL := "http://" + framework.GatewayAddr() + ":8555"
 
-	constructorArgs := []interface{}{fr.GetConfigs().L1RPC, lpAddress}
+	constructorArgs := []interface{}{l1RPCInternalURL, lpAddress}
 	contract := fr.Suave.DeployContract("private-swap.sol/PrivateSwap.json", constructorArgs...)
 
 	// params for confidential request

--- a/examples/private-token-swap/main.go
+++ b/examples/private-token-swap/main.go
@@ -14,9 +14,9 @@ func main() {
 	// deploy some example pool contract with swap function
 	poolContract := fr.L1.DeployContract("pool.sol/Pool.json")
 	lpAddress := poolContract.Raw().Address()
-	l1RPCInternalURL := "http://" + framework.GatewayAddr() + ":8555"
+	l1RPC := fr.GetSuaveL1RPC()
 
-	constructorArgs := []interface{}{l1RPCInternalURL, lpAddress}
+	constructorArgs := []interface{}{l1RPC, lpAddress}
 	contract := fr.Suave.DeployContract("private-swap.sol/PrivateSwap.json", constructorArgs...)
 
 	// params for confidential request

--- a/examples/private-token-swap/main.go
+++ b/examples/private-token-swap/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/flashbots/suapp-examples/framework"
+)
+
+func main() {
+	fr := framework.New()
+	contract := fr.Suave.DeployContract("private-swap.sol/PrivateSwap.json")
+
+	// deploy some example pool contract with swap function
+	poolContract := fr.Suave.DeployContract("pool.sol/Pool.json")
+	lp := poolContract.Raw().Address()
+
+	// params for confidential request
+	from := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	to := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	amount := big.NewInt(100000)
+
+	encodedInputs, err := poolContract.Abi.Methods["swap"].Inputs.Pack(from, to, amount)
+	if err != nil {
+		log.Fatal(err, "failed to pack inputs")
+	}
+
+	receipt := contract.SendConfidentialRequest("example", []interface{}{lp}, encodedInputs)
+
+	swapEvent, err := contract.Abi.Events["Swap"].ParseLog(receipt.Logs[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	amountResult := swapEvent["resultAmount"].(*big.Int)
+	if amountResult.Uint64() != amount.Uint64()*2 {
+		log.Fatal("balance should be swapAmount * 2")
+	}
+}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -251,6 +251,14 @@ func (f *Framework) GetConfigs() *Config {
 	return f.config
 }
 
+func (f *Framework) GetSuaveL1RPC() string {
+	if strings.Contains(f.config.L1RPC, "localhost") {
+		return "http://" + GatewayAddr() + ":" + strings.Split(f.config.L1RPC, ":")[2]
+	}
+
+	return f.config.L1RPC
+}
+
 type Chain struct {
 	rpc        *rpc.Client
 	clt        *sdk.Client


### PR DESCRIPTION
## Description

An example showcasing how to perform a swap where token addresses and amount are confidential, protecting the transaction from sandwich attacks.

Included an illustrative `Pool` contract with a swap function
```solidity
contract Pool {
    ...
    function swap(address from, address to, uint256 amount) external returns (uint256) {
        ...
        return amount * 2;
    }
}
```