### PR TITLE
Add service alias example

### DIFF
--- a/examples/mevm-confidential-store/README.md
+++ b/examples/mevm-confidential-store/README.md
@@ -7,7 +7,7 @@ This example features how to use the Confidential Store.
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/mevm-context/README.md
+++ b/examples/mevm-context/README.md
@@ -9,7 +9,7 @@ The `suave-std` suite provides a high-level interface to the MEVM context with t
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/mevm-is-confidential/README.md
+++ b/examples/mevm-is-confidential/README.md
@@ -7,7 +7,7 @@ This example shows how to use the IsConfidential precompile. This precompile ret
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/offchain-logs/README.md
+++ b/examples/offchain-logs/README.md
@@ -25,7 +25,7 @@ contract ExampleSuapp is Suapp {
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/onchain-callback/README.md
+++ b/examples/onchain-callback/README.md
@@ -9,7 +9,7 @@ Only logs emitted during the onchain execution are available for querying on the
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/onchain-state/README.md
+++ b/examples/onchain-state/README.md
@@ -1,4 +1,3 @@
-
 # Example Suapp with OnChain state
 
 This example shows how Suapps can update state of the smart contract on the Suave chain.
@@ -10,7 +9,7 @@ State variables updated during the confidential request are not updated on the s
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/private-library-confidential-store/README.md
+++ b/examples/private-library-confidential-store/README.md
@@ -1,4 +1,3 @@
-
 # Example Suapp with a Private library
 
 This example shows how Suapps can use private libraries stored in the confidential store that are not public in the Suave chain.
@@ -10,7 +9,7 @@ The private code is saved in the confidential store with the `registerContract` 
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/private-library/README.md
+++ b/examples/private-library/README.md
@@ -1,4 +1,3 @@
-
 # Example Suapp with a Private library
 
 This example shows how Suapps can use private libraries that are not public in the Suave chain.
@@ -10,7 +9,7 @@ The private code is sent inside the confidential part of the confidential comput
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/private-suapp-key-gen/README.md
+++ b/examples/private-suapp-key-gen/README.md
@@ -7,7 +7,7 @@ This is a variation of the [private-suapp-key](../private-suapp-key) example. Th
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/private-suapp-key/README.md
+++ b/examples/private-suapp-key/README.md
@@ -7,7 +7,7 @@ This example shows how Suapps can store private keys in the confidential storage
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:

--- a/examples/service-alias/README.md
+++ b/examples/service-alias/README.md
@@ -1,0 +1,17 @@
+# Example Suapp that uses the service registry
+
+This example shows how Suapps can use the Kettle service registry to resolve HTTP service aliases.
+
+## How to use
+
+Run `Suave` in development mode:
+
+```
+$ suave-geth --suave.dev --suave.service-alias example=https://example.com --suave.eth.external-whitelist='*'
+```
+
+Execute the deployment script:
+
+```
+$ go run main.go
+```

--- a/examples/service-alias/main.go
+++ b/examples/service-alias/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/flashbots/suapp-examples/framework"
+
+func main() {
+	fr := framework.New()
+	fr.Suave.DeployContract("service-alias.sol/ServiceAlias.json").
+		SendConfidentialRequest("example", nil, nil)
+}

--- a/examples/service-alias/service-alias.sol
+++ b/examples/service-alias/service-alias.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.8;
+
+import "suave-std/suavelib/Suave.sol";
+import "suave-std/Suapp.sol";
+
+contract ServiceAlias is Suapp {
+    function exampleCallback() public {}
+
+    function example() public returns (bytes memory) {
+        Suave.HttpRequest memory request;
+        request.url = "example";
+        request.method = "GET";
+        request.timeout = 1000;
+
+        bytes memory response1 = Suave.doHTTPRequest(request);
+
+        // Make the request to the http endpoint
+        request.url = "http://example.com";
+        bytes memory response2 = Suave.doHTTPRequest(request);
+
+        require(keccak256(response1) == keccak256(response2), "Strings should be equal");
+        return abi.encodeWithSelector(this.exampleCallback.selector);
+    }
+}

--- a/examples/service-alias/service-alias.sol
+++ b/examples/service-alias/service-alias.sol
@@ -16,7 +16,7 @@ contract ServiceAlias is Suapp {
         bytes memory response1 = Suave.doHTTPRequest(request);
 
         // Make the request to the http endpoint
-        request.url = "http://example.com";
+        request.url = "https://example.com";
         bytes memory response2 = Suave.doHTTPRequest(request);
 
         require(keccak256(response1) == keccak256(response2), "Strings should be equal");

--- a/examples/std-gateway-erc20/README.md
+++ b/examples/std-gateway-erc20/README.md
@@ -7,7 +7,7 @@ This example features how a Suapp can use the [`Gateway.sol`](https://github.com
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Export the JSON-RPC URL of the chain where the ERC20 contract is deployed:

--- a/examples/std-transaction-signing/README.md
+++ b/examples/std-transaction-signing/README.md
@@ -7,7 +7,7 @@ This example shows how to use the `suave-std` library to create and sign transac
 Run `Suave` in development mode:
 
 ```
-$ suave --suave.dev
+$ suave-geth --suave.dev
 ```
 
 Execute the deployment script:


### PR DESCRIPTION
This PR adds a new example with service alias. Also, it replace the `suave` binary with `suave-geth`.